### PR TITLE
fix: make release on main branch working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .idea
 .DS_Store
 .env
+packages/*/README.md

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "as-proto-workspace",
   "version": "1.0.0",
   "license": "MIT",
+  "author": "Piotr Oleś <piotrek.oles@gmail.com>",
+  "repository": "https://github.com/piotr-oles/as-proto.git",
   "private": true,
   "workspaces": [
     "./packages/*"

--- a/packages/as-proto-gen/package.json
+++ b/packages/as-proto-gen/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "test": "echo 'no tests yet'",
-    "build": "rimraf build && tsc"
+    "build": "rimraf build && tsc",
+    "prepublishOnly": "cp ../../README.md ./"
   }
 }

--- a/packages/as-proto/package.json
+++ b/packages/as-proto/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "test": "asp --verbose",
-    "build": "echo 'no build in as-proto package'"
+    "build": "echo 'no build in as-proto package'",
+    "prepublishOnly": "cp ../../README.md ./"
   }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.1--canary.2.ac827e2.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-proto-gen@0.0.1--canary.2.ac827e2.0
  npm install as-proto@0.0.1--canary.2.ac827e2.0
  # or 
  yarn add as-proto-gen@0.0.1--canary.2.ac827e2.0
  yarn add as-proto@0.0.1--canary.2.ac827e2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
