### PR TITLE
add length param to decode function

### DIFF
--- a/packages/as-proto/assembly/Protobuf.ts
+++ b/packages/as-proto/assembly/Protobuf.ts
@@ -24,9 +24,10 @@ export class Protobuf {
 
   static decode<TMessage>(
     buffer: Uint8Array,
-    decoder: (reader: Reader, length: i32) => TMessage
+    decoder: (reader: Reader, length: i32) => TMessage,
+    length: i32 = -1
   ): TMessage {
     READER.reset(buffer);
-    return decoder(READER, -1);
+    return decoder(READER, length);
   }
 }


### PR DESCRIPTION
Thanks for you awesome work @piotr-oles! I just needed to be able to give a decoder the length of the buffer, so I added an optional parameter to the decode function.