### PR TITLE
chore: add ci workflow for pull_request event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   build-test-release:
     runs-on: ubuntu-latest
@@ -35,7 +35,7 @@ jobs:
         run: yarn test
 
       - name: Release
-        if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+        if: "github.event_name == 'push' && !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1--canary.4.5853465.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-proto-gen@0.1.1--canary.4.5853465.0
  npm install as-proto@0.1.1--canary.4.5853465.0
  # or 
  yarn add as-proto-gen@0.1.1--canary.4.5853465.0
  yarn add as-proto@0.1.1--canary.4.5853465.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
