### PR TITLE
fix: improve reliability for big .proto files

### DIFF
--- a/packages/as-proto-gen/package.json
+++ b/packages/as-proto-gen/package.json
@@ -21,10 +21,12 @@
     "as-proto-gen": "bin/as-proto-gen"
   },
   "devDependencies": {
+    "@types/fs-extra": "^9.0.13",
     "@types/google-protobuf": "^3.15.5",
     "@types/prettier": "^2.4.2"
   },
   "dependencies": {
+    "fs-extra": "^10.1.0",
     "google-protobuf": "^3.19.2",
     "prettier": "^2.5.0",
     "ts-poet": "^4.9.0"

--- a/packages/as-proto-gen/src/index.ts
+++ b/packages/as-proto-gen/src/index.ts
@@ -7,54 +7,63 @@ import { generateFile } from "./generate/file";
 import { getPathWithoutProto } from "./names";
 import { FileContext } from "./file-context";
 import prettier from "prettier";
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import * as assert from "assert";
 
-const input = fs.readFileSync(process.stdin.fd);
-
-try {
-  const codeGenRequest = CodeGeneratorRequest.deserializeBinary(input);
-  const codeGenResponse = new CodeGeneratorResponse();
-  const generatorContext = new GeneratorContext();
-
-  codeGenResponse.setSupportedFeatures(
-    CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL
-  );
-
-  for (const fileDescriptor of codeGenRequest.getProtoFileList()) {
-    const fileDescriptorName = fileDescriptor.getName();
-    assert.ok(fileDescriptorName);
-
-    generatorContext.registerFile(fileDescriptor);
-  }
-
-  for (const fileName of codeGenRequest.getFileToGenerateList()) {
-    const fileDescriptor =
-      generatorContext.getFileDescriptorByFileName(fileName);
-    assert.ok(fileDescriptor);
-
-    const generatedCode = generateFile(
-      fileDescriptor,
-      new FileContext(generatorContext, fileDescriptor)
-    );
-    let formattedCode = generatedCode;
-    try {
-      formattedCode = prettier.format(generatedCode, {
-        parser: "typescript",
-      });
-    } catch (error) {
-      console.error(error);
-    }
-
-    const outputFile = new CodeGeneratorResponse.File();
-    outputFile.setName(getPathWithoutProto(fileName) + ".ts");
-    outputFile.setContent(formattedCode);
-    codeGenResponse.addFile(outputFile);
-  }
-
-  process.stdout.write(Buffer.from(codeGenResponse.serializeBinary().buffer));
-} catch (error) {
+const reportErrorAndExit = (error: unknown) => {
   console.log("An error occurred in as-proto generator plugin.");
   console.error(error);
   process.exit(1);
 }
+
+fs.readFile(process.stdin.fd, (error, input) => {
+  if (error) {
+    reportErrorAndExit(error);
+    return;
+  }
+
+  try {
+    const codeGenRequest = CodeGeneratorRequest.deserializeBinary(input);
+    const codeGenResponse = new CodeGeneratorResponse();
+    const generatorContext = new GeneratorContext();
+
+    codeGenResponse.setSupportedFeatures(
+        CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL
+    );
+
+    for (const fileDescriptor of codeGenRequest.getProtoFileList()) {
+      const fileDescriptorName = fileDescriptor.getName();
+      assert.ok(fileDescriptorName);
+
+      generatorContext.registerFile(fileDescriptor);
+    }
+
+    for (const fileName of codeGenRequest.getFileToGenerateList()) {
+      const fileDescriptor =
+          generatorContext.getFileDescriptorByFileName(fileName);
+      assert.ok(fileDescriptor);
+
+      const generatedCode = generateFile(
+          fileDescriptor,
+          new FileContext(generatorContext, fileDescriptor)
+      );
+      let formattedCode = generatedCode;
+      try {
+        formattedCode = prettier.format(generatedCode, {
+          parser: "typescript",
+        });
+      } catch (error) {
+        console.error(error);
+      }
+
+      const outputFile = new CodeGeneratorResponse.File();
+      outputFile.setName(getPathWithoutProto(fileName) + ".ts");
+      outputFile.setContent(formattedCode);
+      codeGenResponse.addFile(outputFile);
+    }
+
+    process.stdout.write(Buffer.from(codeGenResponse.serializeBinary().buffer));
+  } catch (error) {
+    reportErrorAndExit(error);
+  }
+})

--- a/packages/as-proto-gen/yarn.lock
+++ b/packages/as-proto-gen/yarn.lock
@@ -2,41 +2,80 @@
 # yarn lockfile v1
 
 
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/google-protobuf@^3.15.5":
   version "3.15.5"
   resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.5.tgz#644b2be0f5613b1f822c70c73c6b0e0b5b5fa2ad"
   integrity sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw==
 
-"@types/prettier@^1.19.0":
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
-  integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
+"@types/node@*":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
+  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
 
 "@types/prettier@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
   integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
 
-google-protobuf@^3.19.1:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.19.1.tgz#5af5390e8206c446d8f49febaffd4b7f4ac28f41"
-  integrity sha512-Isv1RlNC+IzZzilcxnlVSf+JvuhxmY7DaxYCBy+zPS9XVuJRtlTTIXR9hnZ1YL1MMusJn/7eSy2swCzZIomQSg==
+fs-extra@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
+google-protobuf@^3.19.2:
+  version "3.20.1"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.20.1.tgz#1b255c2b59bcda7c399df46c65206aa3c7a0ce8b"
+  integrity sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-prettier@^2.0.2, prettier@^2.5.0:
+prettier@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
-ts-poet@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/ts-poet/-/ts-poet-4.6.1.tgz#015dc823d726655af9f095c900f84ed7c60e2dd3"
-  integrity sha512-DXJ+mBJIDp+jiaUgB4N5I/sczHHDU2FWacdbDNVAVS4Mh4hb7ckpvUWVW7m7/nAOcjR0r4Wt+7AoO7FeJKExfA==
+prettier@^2.5.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+ts-poet@^4.9.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/ts-poet/-/ts-poet-4.14.0.tgz#010585df8d7b25d3b6d94a01803020bd8e8c2016"
+  integrity sha512-hLGzWo3H3GLjVubftvaycGSconJrNpjjdpn43Lthnu61l/R2CaPIu+1JhaWZyqh2yj5NaOv+wZ5zoSJzDouAHw==
   dependencies:
-    "@types/prettier" "^1.19.0"
     lodash "^4.17.15"
-    prettier "^2.0.2"
+    prettier "^2.5.1"
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,6 +1320,13 @@
   resolved "https://registry.yarnpkg.com/@types/command-line-usage/-/command-line-usage-5.0.2.tgz#ba5e3f6ae5a2009d466679cc431b50635bf1a064"
   integrity sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==
 
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/google-protobuf@^3.15.5":
   version "3.15.5"
   resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.5.tgz#644b2be0f5613b1f822c70c73c6b0e0b5b5fa2ad"
@@ -1339,6 +1346,11 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
+"@types/node@*":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
+  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
 
 "@types/node@>=13.7.0":
   version "16.11.6"
@@ -2449,6 +2461,15 @@ fromentries@^1.2.0, fromentries@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
   integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
+
+fs-extra@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.1.0:
   version "9.1.0"


### PR DESCRIPTION
Use fs-extra and async function to load .proto file. 
Thanks to @Seb-figment for fixing this.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.5--canary.13.2135fb5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-proto-gen@0.2.5--canary.13.2135fb5.0
  npm install as-proto@0.2.5--canary.13.2135fb5.0
  # or 
  yarn add as-proto-gen@0.2.5--canary.13.2135fb5.0
  yarn add as-proto@0.2.5--canary.13.2135fb5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
