### PR TITLE
Update to AssemblyScript 0.20.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ message StarRepoMessage {
 ```
 ```typescript
 // star-repo-message.ts
-import { Writer, Reader } from "as-proto";
+import { Writer, Reader } from "as-proto/assembly";
 
 export class StarRepoMessage {
   static encode(message: StarRepoMessage, writer: Writer): void {
@@ -103,7 +103,7 @@ To encode and decode protobuf messages, all you need is `Protobuf` class and
 generated message class:
 
 ```typescript
-import { Protobuf } from 'as-proto';
+import { Protobuf } from 'as-proto/assembly';
 import { StarRepoMessage } from './star-repo-message'; // generated file
 
 const message = new StarRepoMessage('piotr-oles', 'as-proto');

--- a/bench/as-proto/asconfig.json
+++ b/bench/as-proto/asconfig.json
@@ -1,23 +1,23 @@
 {
   "targets": {
     "debug": {
+      "outFile": "../data/static_aspr.wasm",
+      "tsdFile": "../data/static_aspr.d.ts"
       "sourceMap": true,
       "debug": true,
       "runtime": "incremental",
-      "exportRuntime": true,
-      "binaryFile": "../data/static_aspr.wasm",
-      "tsdFile": "../data/static_aspr.d.ts"
+      "exportRuntime": true
     },
     "release": {
+      "outFile": "../data/static_aspr.wasm",
+      "textFile": "../data/static_aspr.wat",
+      "tsdFile": "../data/static_aspr.d.ts"
       "sourceMap": true,
       "optimizeLevel": 3,
       "shrinkLevel": 0,
       "runtime": "incremental",
       "converge": false,
-      "noAssert": true,
-      "binaryFile": "../data/static_aspr.wasm",
-      "textFile": "../data/static_aspr.wat",
-      "tsdFile": "../data/static_aspr.d.ts"
+      "noAssert": true
     }
   },
   "options": {}

--- a/bench/as-proto/assembly/generated/bench.ts
+++ b/bench/as-proto/assembly/generated/bench.ts
@@ -1,4 +1,4 @@
-import { Writer, Reader } from "as-proto";
+import { Writer, Reader } from "as-proto/assembly";
 
 export class Test {
   static encode(message: Test, writer: Writer): void {

--- a/bench/as-proto/assembly/static_aspr.ts
+++ b/bench/as-proto/assembly/static_aspr.ts
@@ -1,5 +1,5 @@
 import { Test, Outer } from "./generated/bench";
-import { Protobuf } from "as-proto";
+import { Protobuf } from "as-proto/assembly";
 
 const testDecoded = new Test(
   "Lorem ipsum dolor sit amet.",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "bench": "yarn bench:prepare && node bench"
   },
   "devDependencies": {
-    "@assemblyscript/loader": "^0.19.20",
+    "@assemblyscript/loader": "^0.20.16",
     "@auto-it/conventional-commits": "^10.32.5",
     "@auto-it/first-time-contributor": "^10.32.5",
-    "assemblyscript": "^0.19.20",
+    "assemblyscript": "^0.20.16",
     "auto": "^10.32.5",
     "benchmark": "^2.1.4",
     "chalk": "^4.0.0",

--- a/packages/as-proto-gen/src/generate/message.ts
+++ b/packages/as-proto-gen/src/generate/message.ts
@@ -84,7 +84,7 @@ function generateEncodeMethod(
   const messageName = messageDescriptor.getName();
   assert.ok(messageName);
 
-  const Writer = fileContext.registerImport("Writer", "as-proto");
+  const Writer = fileContext.registerImport("Writer", "as-proto/assembly");
   const Message = fileContext.registerDefinition(messageName);
 
   const scopeContext = new ScopeContext(fileContext, ["message", "writer"]);
@@ -109,7 +109,7 @@ function generateDecodeMethod(
   const messageName = messageDescriptor.getName();
   assert.ok(messageName);
 
-  const Reader = fileContext.registerImport("Reader", "as-proto");
+  const Reader = fileContext.registerImport("Reader", "as-proto/assembly");
   const Message = fileContext.registerDefinition(messageName);
 
   const scopeContext = new ScopeContext(fileContext, [

--- a/packages/as-proto/asconfig.json
+++ b/packages/as-proto/asconfig.json
@@ -9,6 +9,7 @@
     "release": {
       "sourceMap": true,
       "optimizeLevel": 3,
+      "shrinkLevel": 0,
       "runtime": "incremental",
       "exportRuntime": true,
       "converge": false,


### PR DESCRIPTION
After `0.20.x` AssemblyScript required explicit definition for dir with `index.ts`. So in this PR several changes was done:
+ `import {...} from "as-proto"` changed to `import {...} from "as-proto/assembly"`
+ `binaryFile` -> `outFile` in `asconfig.json`

Also, `as-pect` testing framework unfortunately doesn't work with 0.20.x. So you should remove it or migrate to js-based "ava" for example. Also need to update `yarn.lock`.

Maybe I missed something?