### PR TITLE
fix: handle default values and multiple packed fields

### DIFF
--- a/packages/as-proto-gen/src/generate/message.ts
+++ b/packages/as-proto-gen/src/generate/message.ts
@@ -189,7 +189,7 @@ function generateMessageConstructor(
         )}: ${generateFieldType(
           fieldDescriptor,
           fileContext
-        )} = ${generateFieldDefaultValue(fieldDescriptor)}`
+        )} = ${generateFieldDefaultValue(fieldDescriptor, fileContext)}`
     )
     .join(",\n");
   const fieldsAssignments = fields
@@ -242,7 +242,10 @@ function canMessageByUnmanaged(
   });
 }
 
-function generateHelperMethods(message: string, fileContext: FileContext): string {
+function generateHelperMethods(
+  message: string,
+  fileContext: FileContext
+): string {
   const Protobuf = fileContext.registerImport("Protobuf", "as-proto");
 
   const encodeHelper = fileContext.registerDefinition(`encode${message}`);


### PR DESCRIPTION
I'm moving away from as-pect by introducing e2e tests using official tests from protobuf repo. During this process, I found that support for default values and packed fields is buggy. This PR doesn't fix all issues, but at least fixes some of them.