### PR TITLE
Remove `getSafeName()` from `ScopeContext`

### DIFF
--- a/packages/as-proto-gen/src/generate/message.ts
+++ b/packages/as-proto-gen/src/generate/message.ts
@@ -14,6 +14,7 @@ import { FileContext } from "../file-context";
 import { generateEnum } from "./enum";
 import * as assert from "assert";
 import { ScopeContext } from "../scope-context";
+import { getSafeName } from "../reserved-keywords";
 
 export function generateMessage(
   messageDescriptor: DescriptorProto,
@@ -179,12 +180,11 @@ function generateMessageConstructor(
   fileContext: FileContext
 ): string {
   const fields = messageDescriptor.getFieldList();
-  const scopeContext = new ScopeContext(fileContext);
 
   const constructorParams = fields
     .map(
       (fieldDescriptor) =>
-        `${scopeContext.getSafeName(
+        `${getSafeName(
           generateFieldName(fieldDescriptor)
         )}: ${generateFieldType(
           fieldDescriptor,
@@ -195,9 +195,9 @@ function generateMessageConstructor(
   const fieldsAssignments = fields
     .map(
       (fieldDescriptor) =>
-        `this.${generateFieldName(
-          fieldDescriptor
-        )} = ${scopeContext.getSafeName(generateFieldName(fieldDescriptor))}`
+        `this.${generateFieldName(fieldDescriptor)} = ${getSafeName(
+          generateFieldName(fieldDescriptor)
+        )}`
     )
     .join(";\n");
 

--- a/packages/as-proto-gen/src/reserved-keywords.ts
+++ b/packages/as-proto-gen/src/reserved-keywords.ts
@@ -40,3 +40,10 @@ export const RESERVED_KEYWORDS: Set<string> = new Set([
 export function isReservedKeyword(word: string): boolean {
   return RESERVED_KEYWORDS.has(word);
 }
+
+/**
+ * Suffixes name if it's a reserved keyword
+ */
+export function getSafeName(name: string): string {
+  return isReservedKeyword(name) ? `${name}_` : name;
+}

--- a/packages/as-proto-gen/src/scope-context.ts
+++ b/packages/as-proto-gen/src/scope-context.ts
@@ -1,5 +1,5 @@
 import { FileContext } from "./file-context";
-import { isReservedKeyword } from "./reserved-keywords";
+import { getSafeName } from "./reserved-keywords";
 
 export class ScopeContext {
   private readonly fileContext: FileContext;
@@ -18,18 +18,11 @@ export class ScopeContext {
    * Returns a name that is not already reserved.
    */
   getFreeName(preferredName: string): string {
-    let freeName = this.getSafeName(preferredName);
+    let freeName = getSafeName(preferredName);
     let freeSuffix = 2;
     while (this.reservedNames.has(freeName)) {
       freeName = `${preferredName}_${freeSuffix++}`;
     }
     return freeName;
-  }
-
-  /**
-   * Suffixes name if it's a reserved keyword
-   */
-  getSafeName(name: string): string {
-    return isReservedKeyword(name) ? `${name}_` : name;
   }
 }

--- a/tests/as-proto-gen/reserved-keyword.spec.ts
+++ b/tests/as-proto-gen/reserved-keyword.spec.ts
@@ -1,5 +1,8 @@
 import test from "ava";
-import { isReservedKeyword } from "../../packages/as-proto-gen/src/reserved-keywords";
+import {
+  isReservedKeyword,
+  getSafeName,
+} from "../../packages/as-proto-gen/src/reserved-keywords";
 
 test("isReservedKeyword() returns true for reserved keyword", (t) => {
   t.true(isReservedKeyword("for"));
@@ -13,4 +16,12 @@ test("isReservedKeyword() returns false for not reserved keyword", (t) => {
 test("isReservedKeyword() returns false for empty input", (t) => {
   t.false(isReservedKeyword(""));
   t.false(isReservedKeyword("  "));
+});
+
+test("getSafeName() returns original name for non-reserved keyword", (t) => {
+  t.is(getSafeName("blabla"), "blabla");
+});
+
+test("getSafeName() returns suffixed name for reserved keyword", (t) => {
+  t.is(getSafeName("for"), "for_");
 });

--- a/tests/as-proto-gen/scope-context.spec.ts
+++ b/tests/as-proto-gen/scope-context.spec.ts
@@ -10,18 +10,6 @@ test("ScopeContext.getFileContext() returns file context passed to constructor",
   t.is(scopeContext.getFileContext(), fileContext);
 });
 
-test("ScopeContext.getSafeName() returns original name for non-reserved keyword", (t) => {
-  const scopeContext = new ScopeContext(fileContext);
-
-  t.is(scopeContext.getSafeName("blabla"), "blabla");
-});
-
-test("ScopeContext.getSafeName() returns suffixed name for reserved keyword", (t) => {
-  const scopeContext = new ScopeContext(fileContext);
-
-  t.is(scopeContext.getSafeName("for"), "for_");
-});
-
 test("ScopeContext.getFreeName() returns original name for empty reserved set", (t) => {
   const scopeContext = new ScopeContext(fileContext);
 


### PR DESCRIPTION
This is a small part of a bigger plan to migrate to files-output (instead of namespaces). I'm trying to make it as a series of small PRs to make it easy for review.