### PR TITLE
refactor: generalise `getPathWithoutProto` to `getPathWithoutExtension`

### DIFF
--- a/packages/as-proto-gen/src/generate/ref.ts
+++ b/packages/as-proto-gen/src/generate/ref.ts
@@ -1,5 +1,5 @@
 import {
-  getPathWithoutProto,
+  getPathWithoutExtension,
   ensureRelativeImportDot,
   getTypeName,
 } from "../names";
@@ -34,7 +34,7 @@ export function generateRef(
 
     return fileContext.registerImport(
       typeName,
-      ensureRelativeImportDot(getPathWithoutProto(fileName))
+      ensureRelativeImportDot(getPathWithoutExtension(fileName, ".proto"))
     );
   }
 }

--- a/packages/as-proto-gen/src/index.ts
+++ b/packages/as-proto-gen/src/index.ts
@@ -4,7 +4,7 @@ import {
 } from "google-protobuf/google/protobuf/compiler/plugin_pb";
 import { GeneratorContext } from "./generator-context";
 import { generateFile } from "./generate/file";
-import { getPathWithoutProto } from "./names";
+import { getPathWithoutExtension } from "./names";
 import { FileContext } from "./file-context";
 import prettier from "prettier";
 import * as fs from "fs-extra";
@@ -62,7 +62,7 @@ fs.readFile(process.stdin.fd, (error, input) => {
       }
 
       const outputFile = new CodeGeneratorResponse.File();
-      outputFile.setName(getPathWithoutProto(fileName) + ".ts");
+      outputFile.setName(getPathWithoutExtension(fileName, ".proto") + ".ts");
       outputFile.setContent(formattedCode);
       codeGenResponse.addFile(outputFile);
     }

--- a/packages/as-proto-gen/src/names.ts
+++ b/packages/as-proto-gen/src/names.ts
@@ -1,11 +1,16 @@
 /**
- * Removes .proto suffix from the file name
+ * Removes extension suffix from the file path
+ * @param filePath File path to remove extension from
+ * @param extension Extension to remove
+ * @returns File path without extension
  */
-export function getPathWithoutProto(fileName: string): string {
-  const extension = ".proto";
-  return fileName.endsWith(extension)
-    ? fileName.slice(0, -extension.length)
-    : fileName;
+export function getPathWithoutExtension(
+  filePath: string,
+  extension: string
+): string {
+  return filePath.endsWith(extension)
+    ? filePath.slice(0, -extension.length)
+    : filePath;
 }
 
 /**
@@ -36,5 +41,7 @@ export function getTypeName(fieldTypeName: string): string {
  * Ensures that relative import has dot at the beginning.
  */
 export function ensureRelativeImportDot(importName: string): string {
-  return importName.startsWith(".") || importName.startsWith("/") ? importName : `./${importName}`;
+  return importName.startsWith(".") || importName.startsWith("/")
+    ? importName
+    : `./${importName}`;
 }

--- a/tests/as-proto-gen/names.spec.js
+++ b/tests/as-proto-gen/names.spec.js
@@ -1,16 +1,17 @@
 import test from "ava";
 import {
   getFieldTypeName,
-  getPathWithoutProto,
+  getPathWithoutExtension,
   ensureRelativeImportDot,
   getTypeName,
 } from "as-proto-gen/lib/names.js";
 
-test("getPathWithoutProto() returns file name without .proto suffix", (t) => {
-  t.is(getPathWithoutProto("./test.proto"), "./test");
-  t.is(getPathWithoutProto("./test.ts"), "./test.ts");
-  t.is(getPathWithoutProto("./test"), "./test");
-  t.is(getPathWithoutProto(""), "");
+test("getPathWithoutExtension() returns file name without .proto suffix", (t) => {
+  t.is(getPathWithoutExtension("./test.proto", ".proto"), "./test");
+  t.is(getPathWithoutExtension("./test.ts", ".proto"), "./test.ts");
+  t.is(getPathWithoutExtension("./test.ts", ".ts"), "./test");
+  t.is(getPathWithoutExtension("./test", ".ts"), "./test");
+  t.is(getPathWithoutExtension("", ".jpeg"), "");
 });
 
 test("getFieldTypeName() returns valid field type name for package and type", (t) => {


### PR DESCRIPTION
This is a part of a bigger project to move away from namespaces.