### PR TITLE
fix: improve safety when generating field code

### DIFF
--- a/packages/as-proto-gen/src/generate/field.ts
+++ b/packages/as-proto-gen/src/generate/field.ts
@@ -597,10 +597,10 @@ function getFieldMessageDescriptor(
   generatorContext: GeneratorContext
 ): DescriptorProto | undefined {
   assert.ok(fieldDescriptor.getType() === Type.TYPE_MESSAGE);
+  const fieldTypeName = fieldDescriptor.getTypeName();
+  assert.ok(fieldTypeName !== undefined);
 
-  return generatorContext.getMessageDescriptorByFieldTypeName(
-    fieldDescriptor.getTypeName() || ""
-  );
+  return generatorContext.getMessageDescriptorByFieldTypeName(fieldTypeName);
 }
 
 function isMapMessageDescriptor(messageDescriptor: DescriptorProto): boolean {


### PR DESCRIPTION
This is a part of a bigger project to move away from namespaces.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.2--canary.40.a1f0e0f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-proto-gen@0.9.2--canary.40.a1f0e0f.0
  npm install as-proto@0.9.2--canary.40.a1f0e0f.0
  # or 
  yarn add as-proto-gen@0.9.2--canary.40.a1f0e0f.0
  yarn add as-proto@0.9.2--canary.40.a1f0e0f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
