### PR TITLE
feat: handle protobuf dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ export function decodeStarRepoMessage(buffer: Uint8Array): StarRepoMessage {
 }
 ```
 
+### Dependencies
+This package will generate messages for all proto dependencies (for example `import "google/protobuf/timestamp.proto";`) 
+unless you pass `--as_opt=no-gen-dependencies` option.
+
 ## Usage
 To encode and decode protobuf messages, all you need is `Protobuf` class and
 generated message class:
@@ -157,17 +161,7 @@ const encoded = encodeStarRepoMessage(message);
 const decoded = decodeStarRepoMessage(encoded);
 ```
 
-Currently the package doesn't support GRPC definitions - only basic Protobuf messages.
-
-## Using Google Library Types
-
-If your `.proto` definition imports type from `google/protobuf/*`, those types will be referenced and also generated in the AssemblyScript, but only if you pass them explicitly to `protoc`. The `.proto` source files for the `google/protobuf` types will automatically be on the search path for `protoc` - you do not have to find and copy them into your source tree. For example:
-
-```sh
-protoc --plugin=protoc-gen-as=./node_modules/.bin/as-proto-gen --as_out=. ./file.proto google/protobuf/timestamp.proto
-```
-
-will generate `file.as` and `google/protobuf/timestamp.as`.
+Currently, the package doesn't support GRPC definitions - only basic Protobuf messages.
 
 ## Performance
 I used performance benchmark from [`ts-proto`][3] library and added case for `as-proto`.

--- a/packages/as-proto-gen/src/index.ts
+++ b/packages/as-proto-gen/src/index.ts
@@ -33,19 +33,19 @@ fs.readFile(process.stdin.fd, (error, input) => {
     );
 
     for (const fileDescriptor of codeGenRequest.getProtoFileList()) {
-      const fileDescriptorName = fileDescriptor.getName();
-      assert.ok(fileDescriptorName);
-
       generatorContext.registerFile(fileDescriptor);
-    }
 
-    for (const fileName of codeGenRequest.getFileToGenerateList()) {
-      const fileDescriptor =
-        generatorContext.getFileDescriptorByFileName(fileName);
-      assert.ok(fileDescriptor);
+      if (compilerOptions.has("no-gen-dependencies")) {
+        const fileName = fileDescriptor.getName();
+        assert.ok(fileName);
+        if (!codeGenRequest.getFileToGenerateList().includes(fileName)) {
+          // file not listed directly in the command - skip
+          continue;
+        }
+      }
 
       const outputFiles = generateFiles(
-        fileDescriptor,
+        fileDescriptor!,
         generatorContext,
         compilerOptions,
         compilerVersion

--- a/tests/assembly/.gitignore
+++ b/tests/assembly/.gitignore
@@ -3,3 +3,4 @@
 *.js
 *.d.ts
 asproto
+google


### PR DESCRIPTION
This PR fixes how `as-proto-gen` handles `import` statements inside `.proto` files. You no longer have to manually add dependencies to the generate command - it will be handled automatically, unless you specify `--as_opt=no-gen-dependencies` option.

Closes: #38