### PR TITLE
read buffer directly when parsing string

### DIFF
--- a/packages/as-proto/assembly/internal/FixedReader.ts
+++ b/packages/as-proto/assembly/internal/FixedReader.ts
@@ -95,8 +95,8 @@ export class FixedReader extends Reader {
   }
 
   string(): string {
-    const bytes = this.bytes();
-    return String.UTF8.decodeUnsafe(bytes.dataStart, bytes.byteLength);
+    const length = this.uint32();
+    return String.UTF8.decodeUnsafe(this.inc(length), length);
   }
 
   skip(length: u32): void {


### PR DESCRIPTION
Seems to be a consequence-free performance improvement unless I'm missing something.

Each time a string is read, instead of creating a copy of the slice of the input buffer which then is used to make another copy of the data in string form, just read directly from the original input buffer when decoding into a string. Avoiding that extra allocation saves some time.