### PR TITLE
Remove unmanaged decorator from generated output

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,7 @@ google-protobuf x 160,281 ops/sec ±0.46% (91 runs sampled)
 
 The library is slower on decoding mostly because of GC - AssemblyScript provides very simple (and small) GC
 which is not as good as V8 GC. The `as-proto` beats JavaScript on decoding when messages contain
-only primitive values or other messages (no strings and arrays). In this case the generator creates
-`@unmanaged` classes which are much faster for memory management.
+only primitive values or other messages (no strings and arrays).
 
 ## License
 MIT

--- a/bench/data/assembly/generated/Test/Inner/InnerInner.ts
+++ b/bench/data/assembly/generated/Test/Inner/InnerInner.ts
@@ -6,7 +6,6 @@
 import { Writer, Reader } from "as-proto/assembly";
 import { Enum } from "../Enum";
 
-@unmanaged
 export class InnerInner {
   static encode(message: InnerInner, writer: Writer): void {
     writer.uint32(8);


### PR DESCRIPTION
- using unmanaged decorator causes memory leaks because instances of the unmanaged class don't get cleaned up by GC. Remove that output from the generators and update README to remove reference to it.

Fixes https://github.com/piotr-oles/as-proto/issues/47