### PR TITLE
support package-less protos with well known imports

### DIFF
--- a/packages/as-proto-gen/src/generate/file.ts
+++ b/packages/as-proto-gen/src/generate/file.ts
@@ -86,12 +86,18 @@ export function getOutputFilePath(
   assert.ok(messageName !== undefined);
 
   const outputFileName = sanitizeFileName(`${messageName}.ts`);
+  const path = [outputFileName];
+  const filePrefix = getFilePrefix(fileDescriptor);
+  const nestedMessagePrefix = getNestedMessagePrefix(parentMessageDescriptors);
 
-  return [
-    getFilePrefix(fileDescriptor),
-    getNestedMessagePrefix(parentMessageDescriptors),
-    outputFileName,
-  ].join("/");
+  if (nestedMessagePrefix) {
+    path.unshift(nestedMessagePrefix);
+  }
+
+  if (filePrefix) {
+    path.unshift(filePrefix);
+  }
+  return path.join("/");
 }
 
 function generateMessageFiles(

--- a/packages/as-proto-gen/src/generate/file.ts
+++ b/packages/as-proto-gen/src/generate/file.ts
@@ -86,18 +86,12 @@ export function getOutputFilePath(
   assert.ok(messageName !== undefined);
 
   const outputFileName = sanitizeFileName(`${messageName}.ts`);
-  const path = [outputFileName];
-  const filePrefix = getFilePrefix(fileDescriptor);
-  const nestedMessagePrefix = getNestedMessagePrefix(parentMessageDescriptors);
 
-  if (nestedMessagePrefix) {
-    path.unshift(nestedMessagePrefix);
-  }
-
-  if (filePrefix) {
-    path.unshift(filePrefix);
-  }
-  return path.join("/");
+  return [
+    getFilePrefix(fileDescriptor),
+    getNestedMessagePrefix(parentMessageDescriptors),
+    outputFileName,
+  ].filter(part => part !== undefined && part !== '').join("/");
 }
 
 function generateMessageFiles(


### PR DESCRIPTION
Fixes: https://github.com/piotr-oles/as-proto/issues/51

Support package-less protos with well known imports by not joining undefined values in the output file path. 