### PR TITLE
Remove `null`, use default values instead

### DIFF
--- a/packages/as-proto-gen/src/generate/field.ts
+++ b/packages/as-proto-gen/src/generate/field.ts
@@ -541,10 +541,10 @@ export function isNullableFieldType(
 ): boolean {
   const fieldType = fieldDescriptor.getType();
   assert.ok(fieldType !== undefined);
-  // There is no null in protobuf3.
-  // It is not possible to distinguish between a message with default values
-  // versus a "null" message.
-  return false;
+  // There is no null in protobuf3 in the sense that empty bytes always
+  // successfully deserialize to default message values.
+  // But if a field is explicitly set as optional, it may be null.
+  return fieldDescriptor.hasProto3Optional();
 }
 
 export function isManagedFieldType(

--- a/packages/as-proto-gen/src/generate/field.ts
+++ b/packages/as-proto-gen/src/generate/field.ts
@@ -437,7 +437,7 @@ export function generateFieldDefaultValue(
         // TODO: handle default value for bytes
         return "new Uint8Array(0)";
       case Type.TYPE_MESSAGE:
-        return generateFieldMessageDefaultValue(fieldDescriptor, keyType);
+        return generateFieldMessageDecodeEmptyBytes(fieldDescriptor, keyType);
       default:
         throw new Error(
           `Type "${fieldDescriptor.getTypeName()}" (${fieldDescriptor.getType()}) is not supported by as-proto-gen`
@@ -475,7 +475,7 @@ function generateFieldBasicDefaultValue(
     case Type.TYPE_BYTES:
       return "new Uint8Array(0)";
     case Type.TYPE_MESSAGE:
-      return generateFieldMessageDefaultValue(fieldDescriptor, type);
+      return `new ${type}()`;
     default:
       throw new Error(
         `Type "${fieldDescriptor.getTypeName()}" (${fieldDescriptor.getType()}) is not supported by as-proto-gen`
@@ -483,7 +483,7 @@ function generateFieldBasicDefaultValue(
   }
 }
 
-function generateFieldMessageDefaultValue(
+function generateFieldMessageDecodeEmptyBytes(
   fieldDescriptor: FieldDescriptorProto,
   type: string,
 ): string {

--- a/packages/as-proto-gen/src/generate/message.ts
+++ b/packages/as-proto-gen/src/generate/message.ts
@@ -101,7 +101,7 @@ function generateDecodeMethod(
 
   const Reader = fileContext.registerImport("Reader", "as-proto/assembly");
   const Message = fileContext.registerDefinition(messageName);
-  const Protobuf = fileContext.registerImport("Protobuf", "as-proto/assembly");
+  fileContext.registerImport("Protobuf", "as-proto/assembly");
 
   const scopeContext = new ScopeContext(fileContext, [
     "reader",
@@ -114,7 +114,7 @@ function generateDecodeMethod(
   return `
     static decode(reader: ${Reader}, length: i32): ${Message} {
       const end: usize = length < 0 ? reader.end : reader.ptr + length;
-      const message = ${Protobuf}.decode<${Message}>(new Uint8Array(0), ${Message}.decode);
+      const message = new ${Message}();
 
       while (reader.ptr < end) {
         const tag = reader.uint32();


### PR DESCRIPTION
This PR follows up on my comment: https://github.com/piotr-oles/as-proto/pull/8#discussion_r1768796870.

I could be wrong on this, and/or it may just be personal preference, but I think it is nicer to not have `null` and instead have the default message values available (unless explicitly marked as `optional`). To check if something is missing a property such as `hasValue` can be set on the message.

Any feedback on this is appreciated!